### PR TITLE
Fix SharePageContent hooks

### DIFF
--- a/src/components/SharePageContent.tsx
+++ b/src/components/SharePageContent.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { generateDownloadLink, getFileInfo } from '@/services/fileService';
 import type { FileInfo } from '@/types/file';
 import { AnimatePresence, motion } from 'framer-motion';


### PR DESCRIPTION
## Summary
- mark SharePageContent component as client-side to allow hooks

## Testing
- `npm run check` *(fails: biome not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443a931d0c832b9a818166eab2a71b