### PR TITLE
Fix file not found response

### DIFF
--- a/src/app/api/file/[keyFile]/route.ts
+++ b/src/app/api/file/[keyFile]/route.ts
@@ -23,9 +23,12 @@ export async function GET(
 		}
 	});
 
-	if (!fileRecord) {
-		return NextResponse.json({ message: 'File not found' }, { status: 404 });
-	}
+        if (!fileRecord) {
+                return NextResponse.json(
+                        { error: 'File not found' },
+                        { status: 404 }
+                );
+        }
 
 	const downloadCount = await prisma.download.count({
 		where: { fileId: fileRecord.id }


### PR DESCRIPTION
## Summary
- return `{ error: 'File not found' }` for missing files
- keep `getFileInfo` error parsing working

## Testing
- `npm run check` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443c42acf4832b9a83c95a9023a6b8